### PR TITLE
Ability Renaming + Move Updates

### DIFF
--- a/calc/src/data/moves.ts
+++ b/calc/src/data/moves.ts
@@ -3352,7 +3352,7 @@ const SS_PATCH: {[name: string]: DeepPartial<MoveData>} = {
     'isPulse': true
   },
   'Surf': {
-    'bp': 95,
+    'bp': 90,
     'type': 'Water',
     'category': 'Special',
     'acc': 100,
@@ -3970,7 +3970,7 @@ const SS_PATCH: {[name: string]: DeepPartial<MoveData>} = {
   },
   'Spike Cannon': {
     'bp': 25,
-    'type': 'Normal',
+    'type': 'Water',
     'category': 'Physical',
     'acc': 100,
     'priority': 0,
@@ -5509,7 +5509,7 @@ const SS_PATCH: {[name: string]: DeepPartial<MoveData>} = {
     'isAir': true
   },
   'Overheat': {
-    'bp': 140,
+    'bp': 130,
     'type': 'Fire',
     'category': 'Special',
     'acc': 100,

--- a/calc/src/data/moves.ts
+++ b/calc/src/data/moves.ts
@@ -3970,7 +3970,7 @@ const SS_PATCH: {[name: string]: DeepPartial<MoveData>} = {
   },
   'Spike Cannon': {
     'bp': 25,
-    'type': 'Water',
+    'type': 'Normal',
     'category': 'Physical',
     'acc': 100,
     'priority': 0,

--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -258,10 +258,10 @@ export function calculateSMSSSV(
   let isGalvanize = false;
   let isLiquidVoice = false;
   let isNormalize = false;
-  let isBuginize = false;
-  let isPoisonate = false;
+  let isPollinate = false;
+  let isIntoxicate = false;
   let isHydrate = false;
-  let isGroundate = false;
+  let isTectonize = false;
   let isFightingSpirit = false;
   let isCrystallize = false;
   let isImmolate = false;
@@ -294,13 +294,13 @@ export function calculateSMSSSV(
       type = 'Ice';
     } else if ((isNormalize = !!attacker.hasAbility('Normalize'))) { // Boosts any type
       type = 'Normal';
-    } else if ((isBuginize = !!attacker.hasAbility('Buginize')) && normal) {
+    } else if ((isPollinate = !!attacker.hasAbility('Pollinate')) && normal) {
       type = 'Bug';
-    } else if ((isPoisonate = !!attacker.hasAbility('Poisonate') && normal)) {
+    } else if ((isIntoxicate = !!attacker.hasAbility('Intoxicate') && normal)) {
       type = 'Poison';
     } else if ((isHydrate = !!attacker.hasAbility('Hydrate')) && normal) {
       type = 'Water';
-    } else if ((isGroundate = !!attacker.hasAbility('Groundate')) && normal) {
+    } else if ((isTectonize = !!attacker.hasAbility('Tectonize')) && normal) {
       type = 'Ground';
     } else if ((isFightingSpirit = !!attacker.hasAbility('Fighting Spirit')) && normal) {
       type = 'Fighting';
@@ -315,8 +315,8 @@ export function calculateSMSSSV(
     } else if ((isMineralize = !!attacker.hasAbility('Mineralize')) && normal){
       type = 'Rock';
     }
-    if (isGalvanize || isPixilate || isRefrigerate || isAerilate || isNormalize || isBuginize ||
-      isPoisonate || isHydrate || isGroundate || isFightingSpirit || isCrystallize || isImmolate ||
+    if (isGalvanize || isPixilate || isRefrigerate || isAerilate || isNormalize || isPollinate ||
+      isIntoxicate || isHydrate || isTectonize || isFightingSpirit || isCrystallize || isImmolate ||
       isSpectralize || isDraconize || isMineralize) {
       desc.attackerAbility = appSpacedStr(desc.attackerAbility, attacker.ability);
       hasAteAbilityTypeChange = true;


### PR DESCRIPTION
Renames Buginize, Poisonate and Groundate to Pollinate, Intoxicate and Tectonize respectively.

However, one thing I could not figure out is that these types of ability (exclusively the ones introduced by ER) boost the power of all moves of that type by 10%, not only the normal moves that got their type changed (which is the intended behavior)

example: a pokemon with immolate as their ability, flare blitz and double edge as their attacks, does the same damage with both flare blitz and double edge, despite double edge supposedly being the only attack getting the 10% ability boost.

Also updates some moves that got values changed/reverted during commit https://github.com/ForwardFeed/Redux-Elite-Calc/commit/f1071596609056f02994eb6edc56434d00ecf925 + surf to 90 BP (overheat back to 130, spike cannon to water type)