### PR TITLE
more bug fixes + corrosion implementation

### DIFF
--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -460,7 +460,8 @@ export function calculateSMSSSV(
     } else if (typeEffectiveness < 0.5) {
       typeEffectiveness *= 2;
     }
-  } else if (attacker.hasAbility('Molten Down') && defender.hasType('Rock') &&
+  } 
+  if (attacker.hasAbility('Molten Down') && defender.hasType('Rock') &&
    move.type === 'Fire') {
     typeEffectiveness = typeEffectiveness * 4;
   }
@@ -474,7 +475,11 @@ export function calculateSMSSSV(
   }
   if (attacker.hasAbility('Ground Shock') && move.hasType('Electric') &&
   defender.hasType('Ground')) {
-    typeEffectiveness = typeEffectiveness ? typeEffectiveness : 2 / 2;
+    typeEffectiveness = typeEffectiveness ? typeEffectiveness : 0.5;
+  }
+  if (attacker.hasAbility('Corrosion') && move.hasType('Poison') && 
+  defender.hasType('Steel')) {
+    typeEffectiveness = typeEffectiveness ? typeEffectiveness : 2;
   }
 
   if (typeEffectiveness === 0 && move.hasType('Ground') &&

--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -294,25 +294,25 @@ export function calculateSMSSSV(
       type = 'Ice';
     } else if ((isNormalize = !!attacker.hasAbility('Normalize'))) { // Boosts any type
       type = 'Normal';
-    } else if ((isPollinate = !!attacker.hasAbility('Pollinate')) && normal) {
+    } else if ((isPollinate = !!attacker.hasAbility('Pollinate') && normal)) {
       type = 'Bug';
     } else if ((isIntoxicate = !!attacker.hasAbility('Intoxicate') && normal)) {
       type = 'Poison';
-    } else if ((isHydrate = !!attacker.hasAbility('Hydrate')) && normal) {
+    } else if ((isHydrate = !!attacker.hasAbility('Hydrate') && normal)) {
       type = 'Water';
-    } else if ((isTectonize = !!attacker.hasAbility('Tectonize')) && normal) {
+    } else if ((isTectonize = !!attacker.hasAbility('Tectonize') && normal)) {
       type = 'Ground';
-    } else if ((isFightingSpirit = !!attacker.hasAbility('Fighting Spirit')) && normal) {
+    } else if ((isFightingSpirit = !!attacker.hasAbility('Fighting Spirit') && normal)) {
       type = 'Fighting';
-    } else if ((isCrystallize = !!attacker.hasAbility('Crystallize')) && move.hasType('Rock')) {
+    } else if ((isCrystallize = !!attacker.hasAbility('Crystallize') && move.hasType('Rock'))) {
       type = 'Ice';
-    } else if ((isImmolate = !!attacker.hasAbility('Immolate')) && normal) {
+    } else if ((isImmolate = !!attacker.hasAbility('Immolate') && normal)) {
       type = 'Fire';
-    } else if ((isSpectralize = !!attacker.hasAbility('Spectralize')) && normal){
+    } else if ((isSpectralize = !!attacker.hasAbility('Spectralize') && normal)) {
       type = 'Ghost';
-    } else if ((isDraconize = !!attacker.hasAbility('Draconize')) && normal){
+    } else if ((isDraconize = !!attacker.hasAbility('Draconize') && normal)) {
       type = 'Dragon';
-    } else if ((isMineralize = !!attacker.hasAbility('Mineralize')) && normal){
+    } else if ((isMineralize = !!attacker.hasAbility('Mineralize') && normal)) {
       type = 'Rock';
     }
     if (isGalvanize || isPixilate || isRefrigerate || isAerilate || isNormalize || isPollinate ||

--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -358,7 +358,7 @@ export function calculateSMSSSV(
   }
   if (attacker.hasAbility('Dragonfly', 'Half Drake')) {
     attacker.types.push('Dragon');
-  } else if (defender.hasAbility('Dragonfly')) {
+  } else if (defender.hasAbility('Dragonfly', 'Half Drake')) {
     defender.types.push('Dragon');
   }
   if (attacker.hasAbility('Ice Age')) {

--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -294,25 +294,25 @@ export function calculateSMSSSV(
       type = 'Ice';
     } else if ((isNormalize = !!attacker.hasAbility('Normalize'))) { // Boosts any type
       type = 'Normal';
-    } else if ((isPollinate = !!attacker.hasAbility('Pollinate') && normal)) {
+    } else if ((isPollinate = !!attacker.hasAbility('Pollinate')) && normal) {
       type = 'Bug';
     } else if ((isIntoxicate = !!attacker.hasAbility('Intoxicate') && normal)) {
       type = 'Poison';
-    } else if ((isHydrate = !!attacker.hasAbility('Hydrate') && normal)) {
+    } else if ((isHydrate = !!attacker.hasAbility('Hydrate')) && normal) {
       type = 'Water';
-    } else if ((isTectonize = !!attacker.hasAbility('Tectonize') && normal)) {
+    } else if ((isTectonize = !!attacker.hasAbility('Tectonize')) && normal) {
       type = 'Ground';
-    } else if ((isFightingSpirit = !!attacker.hasAbility('Fighting Spirit') && normal)) {
+    } else if ((isFightingSpirit = !!attacker.hasAbility('Fighting Spirit')) && normal) {
       type = 'Fighting';
-    } else if ((isCrystallize = !!attacker.hasAbility('Crystallize') && move.hasType('Rock'))) {
+    } else if ((isCrystallize = !!attacker.hasAbility('Crystallize')) && move.hasType('Rock')) {
       type = 'Ice';
-    } else if ((isImmolate = !!attacker.hasAbility('Immolate') && normal)) {
+    } else if ((isImmolate = !!attacker.hasAbility('Immolate')) && normal) {
       type = 'Fire';
-    } else if ((isSpectralize = !!attacker.hasAbility('Spectralize') && normal)) {
+    } else if ((isSpectralize = !!attacker.hasAbility('Spectralize')) && normal){
       type = 'Ghost';
-    } else if ((isDraconize = !!attacker.hasAbility('Draconize') && normal)) {
+    } else if ((isDraconize = !!attacker.hasAbility('Draconize')) && normal){
       type = 'Dragon';
-    } else if ((isMineralize = !!attacker.hasAbility('Mineralize') && normal)) {
+    } else if ((isMineralize = !!attacker.hasAbility('Mineralize')) && normal){
       type = 'Rock';
     }
     if (isGalvanize || isPixilate || isRefrigerate || isAerilate || isNormalize || isPollinate ||

--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -462,17 +462,17 @@ export function calculateSMSSSV(
     }
   } else if (attacker.hasAbility('Molten Down') && defender.hasType('Rock') &&
    move.type === 'Fire') {
-    typeEffectiveness = 2;
+    typeEffectiveness = typeEffectiveness * 4;
   }
-  if (attacker.hasAbility('Seaweed Grass') && move.hasType('Grass') &&
+  if (attacker.hasAbility('Seaweed') && move.hasType('Grass') &&
     defender.hasType('Fire')) {
     typeEffectiveness = typeEffectiveness * 2;
   }
-  if (defender.hasAbility('Seaweed Grass') && move.hasType('Fire') &&
+  if (defender.hasAbility('Seaweed') && move.hasType('Fire') &&
   defender.hasType('Grass')) {
     typeEffectiveness = typeEffectiveness / 2;
   }
-  if (defender.hasAbility('Ground Shock') && move.hasType('Electric') &&
+  if (attacker.hasAbility('Ground Shock') && move.hasType('Electric') &&
   defender.hasType('Ground')) {
     typeEffectiveness = typeEffectiveness ? typeEffectiveness : 2 / 2;
   }


### PR DESCRIPTION
Adds Half Drake's dragon type on the defender when attacked

Shifts the parenthesis position to mirror implementation of the official showdown calculator

Renames Seaweed Grass to Seaweed

Attempt to fix Molten Down and Ground Shock implementation

Adds Corrosion type effectiveness against steel going from immune to super effective
