### PR TITLE
Unaware Fix

### DIFF
--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -1359,7 +1359,7 @@ export function calculateAttackSMSSSV(
   if (attackSource.boosts[attackStat] === 0 ||
       (isCritical && attackSource.boosts[attackStat] < 0)) {
     attack = attackSource.rawStats[attackStat];
-  } else if (defender.hasAbility('Unaware') || attacker.hasAbility('Unaware')) {
+  } else if (defender.hasAbility('Unaware')) {
     attack = attackSource.rawStats[attackStat];
     desc.defenderAbility = appSpacedStr(desc.defenderAbility, defender.descAbility);
   } else {
@@ -1386,7 +1386,13 @@ export function calculateAttackSMSSSV(
   if (attacker.hasAbility('Juggernaut') && move.flags.contact) {
     attack = attacker.stats.atk + pokeRound((attacker.stats.def * 0.20));
   }
-  if (attacker.hasAbility('Power Core')) {
+  if (attacker.hasAbility('Power Core') && defender.hasAbility('Unaware')) {
+    if (move.category === 'Physical') {
+      attack = attackSource.rawStats[attackStat] + pokeRound((attacker.stats.def * 0.25));
+    } else {
+      attack = attackSource.rawStats[attackStat] + pokeRound((attacker.stats.spd * 0.25));
+    }
+  } else if (attacker.hasAbility('Power Core') && !defender.hasAbility('Unaware')) {
     if (move.category === 'Physical') {
       attack = attacker.stats.atk + pokeRound((attacker.stats.def * 0.25));
     } else {


### PR DESCRIPTION
So, the problem was actually power core, not unaware. When I saw unaware not working it was with arceus, which has power core as one of its abilities. Power Core was ALWAYS using the pokemons attack after modifications, completely skipping raw stats if unaware was active. Your fix for unaware didn't do anything aside from making the unaware mon ignore its own stat boosts which is not how it works in game.

My apologies for not having described properly nor realized that there could be something else broken instead of unaware